### PR TITLE
Do not render next button if no child

### DIFF
--- a/components/Explorer.tsx
+++ b/components/Explorer.tsx
@@ -102,9 +102,11 @@ function Child({ child, onClick }: ChildProps) {
         <Heading marginRight={majorScale(1)}>{child.name}</Heading>
         <Pill>{child.count}</Pill>
       </Pane>
-      <Pane>
-        <IconButton icon={ChevronRightIcon} onClick={onClick} />
-      </Pane>
+      {Object.keys(child.children).length > 0 && (
+        <Pane>
+          <IconButton icon={ChevronRightIcon} onClick={onClick} />
+        </Pane>
+      )}
     </Card>
   );
 }


### PR DESCRIPTION
If a meter doesn't have any child, it would be better to remove next button. So users don't waste their time to see empty children.