### PR TITLE
Trigger CD workflow from release workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     tags: ['v*']
+  workflow_call:
 
 jobs:
   docker:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,3 +48,8 @@ jobs:
         run: release-cli release ${{ inputs.bump && format('--bump {0}', inputs.bump) || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy:
+    needs: release
+    uses: ./.github/workflows/cd.yml
+    secrets: inherit


### PR DESCRIPTION
#### Motivation

The 0.4.0 release tag was created by the release workflow using the default `GITHUB_TOKEN`, which does not trigger other workflows (GitHub's infinite-loop prevention). As a result, the CD workflow was not triggered and Docker images were not built for the release.

#### Modifications

- Added `workflow_call` trigger to `cd.yml` so it can be called by other workflows
- Added a `deploy` job to `release.yml` that chains the CD workflow after the release job completes

#### Result

The CD workflow now runs automatically after every release, building and pushing Docker images. It also continues to trigger independently on pushes to `main` and manual tag pushes.